### PR TITLE
Fix Open Graph image generation routes

### DIFF
--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,82 +1,10 @@
-import { ImageResponse } from "next/og";
+import { generateOgImage, ogImageSize } from "@/lib/og-image";
 
 export const runtime = "edge";
 export const alt = "Nirav Mehta - Fullstack Developer";
-export const size = {
-  width: 1200,
-  height: 630,
-};
+export const size = ogImageSize;
 export const contentType = "image/png";
 
-// Oxocarbon Dark colors
-const colors = {
-  base: "#161616",
-  text: "#f2f4f8",
-  subtext: "#dde1e6",
-  overlay: "#525252",
-  accent: "#78a9ff",
-};
-
-export default async function Image() {
-  return new ImageResponse(
-    (
-      <div
-        style={{
-          height: "100%",
-          width: "100%",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "flex-start",
-          justifyContent: "center",
-          backgroundColor: colors.base,
-          padding: "80px",
-        }}
-      >
-        <div
-          style={{
-            fontSize: 80,
-            fontWeight: 700,
-            color: colors.text,
-            marginBottom: 20,
-            lineHeight: 1.1,
-          }}
-        >
-          hi, i'm <span style={{ color: colors.accent }}>nirav</span>
-        </div>
-        <div
-          style={{
-            fontSize: 40,
-            color: colors.subtext,
-            marginBottom: 10,
-          }}
-        >
-          fullstack <span style={{ color: colors.accent }}>developer</span> and{" "}
-          <span style={{ color: colors.accent }}>computer science junior</span>
-        </div>
-        <div
-          style={{
-            fontSize: 32,
-            color: colors.overlay,
-            fontStyle: "italic",
-          }}
-        >
-          i like cats
-        </div>
-        <div
-          style={{
-            position: "absolute",
-            bottom: 60,
-            right: 80,
-            fontSize: 28,
-            color: colors.overlay,
-          }}
-        >
-          ni3rav.me
-        </div>
-      </div>
-    ),
-    {
-      ...size,
-    }
-  );
+export default function Image() {
+  return generateOgImage();
 }

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -1,82 +1,10 @@
-import { ImageResponse } from "next/og";
+import { generateOgImage, ogImageSize } from "@/lib/og-image";
 
 export const runtime = "edge";
 export const alt = "Nirav Mehta - Fullstack Developer";
-export const size = {
-  width: 1200,
-  height: 630,
-};
+export const size = ogImageSize;
 export const contentType = "image/png";
 
-// Oxocarbon Dark colors
-const colors = {
-  base: "#161616",
-  text: "#f2f4f8",
-  subtext: "#dde1e6",
-  overlay: "#525252",
-  accent: "#78a9ff",
-};
-
-export default async function Image() {
-  return new ImageResponse(
-    (
-      <div
-        style={{
-          height: "100%",
-          width: "100%",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "flex-start",
-          justifyContent: "center",
-          backgroundColor: colors.base,
-          padding: "80px",
-        }}
-      >
-        <div
-          style={{
-            fontSize: 80,
-            fontWeight: 700,
-            color: colors.text,
-            marginBottom: 20,
-            lineHeight: 1.1,
-          }}
-        >
-          hi, i'm <span style={{ color: colors.accent }}>nirav</span>
-        </div>
-        <div
-          style={{
-            fontSize: 40,
-            color: colors.subtext,
-            marginBottom: 10,
-          }}
-        >
-          fullstack <span style={{ color: colors.accent }}>developer</span> and{" "}
-          <span style={{ color: colors.accent }}>computer science junior</span>
-        </div>
-        <div
-          style={{
-            fontSize: 32,
-            color: colors.overlay,
-            fontStyle: "italic",
-          }}
-        >
-          i like cats
-        </div>
-        <div
-          style={{
-            position: "absolute",
-            bottom: 60,
-            right: 80,
-            fontSize: 28,
-            color: colors.overlay,
-          }}
-        >
-          ni3rav.me
-        </div>
-      </div>
-    ),
-    {
-      ...size,
-    }
-  );
+export default function Image() {
+  return generateOgImage();
 }

--- a/lib/og-image.tsx
+++ b/lib/og-image.tsx
@@ -1,0 +1,91 @@
+import { ImageResponse } from "next/og";
+
+export const ogImageSize = {
+  width: 1200,
+  height: 630,
+};
+
+const colors = {
+  base: "#161616",
+  text: "#f2f4f8",
+  subtext: "#dde1e6",
+  overlay: "#525252",
+  accent: "#78a9ff",
+};
+
+export function generateOgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-start",
+          justifyContent: "center",
+          backgroundColor: colors.base,
+          padding: "80px",
+          position: "relative",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            gap: 20,
+            fontSize: 80,
+            fontWeight: 700,
+            color: colors.text,
+            marginBottom: 20,
+            lineHeight: 1.1,
+          }}
+        >
+          <span>hi, i&apos;m</span>
+          <span style={{ color: colors.accent }}>nirav</span>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 10,
+            fontSize: 40,
+            color: colors.subtext,
+            marginBottom: 12,
+          }}
+        >
+          <span>fullstack</span>
+          <span style={{ color: colors.accent }}>developer</span>
+          <span>and</span>
+          <span style={{ color: colors.accent }}>computer science junior</span>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            fontSize: 32,
+            color: colors.overlay,
+            fontStyle: "italic",
+          }}
+        >
+          i like cats
+        </div>
+
+        <div
+          style={{
+            position: "absolute",
+            bottom: 60,
+            right: 80,
+            display: "flex",
+            fontSize: 28,
+            color: colors.overlay,
+          }}
+        >
+          ni3rav.me
+        </div>
+      </div>
+    ),
+    ogImageSize
+  );
+}


### PR DESCRIPTION
### Motivation
- Open Graph/Twitter image routes were returning runtime 500s under Next.js 16 because Satori required explicit layout on multi-child containers, so the OG generator needed to be corrected and centralized.

### Description
- Add a shared OG generator in `lib/og-image.tsx` that exports `generateOgImage()` and `ogImageSize` and returns a `new ImageResponse(...)` for the OG markup.
- Update `app/opengraph-image.tsx` and `app/twitter-image.tsx` to import and use `generateOgImage` and `ogImageSize` so both endpoints stay in sync.
- Update the OG template markup so every container with more than one child explicitly sets `display: "flex"`, preventing the Satori layout error.

### Testing
- Ran `curl -I http://127.0.0.1:3000/opengraph-image` and `curl -I http://127.0.0.1:3000/twitter-image` and both returned `HTTP/1.1 200 OK` with `content-type: image/png`.
- Captured a screenshot of the generated OG image using a Playwright script and saved it as an artifact (`artifacts/opengraph-image-preview.png`).
- `npm run build` fails in this environment due to an external Google Fonts fetch being blocked during build (environmental issue).
- `npx tsc --noEmit` reports an existing unrelated type error in `components/ui/calendar.tsx` that was not introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994696065a4832389f347c5b5176c9f)